### PR TITLE
Metadata handling

### DIFF
--- a/notebooks/data_structures.ipynb
+++ b/notebooks/data_structures.ipynb
@@ -48,7 +48,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -557,7 +557,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1144,7 +1144,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 25,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1153,7 +1153,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 26,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -1220,7 +1220,7 @@
        "2     read3     3000   4000      300    400"
       ]
      },
-     "execution_count": 26,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1238,7 +1238,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 27,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1247,7 +1247,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 28,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1256,7 +1256,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 29,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -1323,7 +1323,7 @@
        "2     read3      300    400     3000   4000"
       ]
      },
-     "execution_count": 29,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1341,7 +1341,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 30,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -1350,7 +1350,7 @@
        "True"
       ]
      },
-     "execution_count": 30,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1368,7 +1368,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 31,
+   "execution_count": 21,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1377,7 +1377,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 32,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -1452,7 +1452,7 @@
        "2     read3     3000   4000      300    400      100    200"
       ]
      },
-     "execution_count": 32,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1463,7 +1463,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 33,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -1538,7 +1538,7 @@
        "2     read3      100    200      300    400     3000   4000"
       ]
      },
-     "execution_count": 33,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1592,16 +1592,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 39,
+   "execution_count": 32,
    "metadata": {},
    "outputs": [],
    "source": [
-    "contacts = FileManager().load_contacts(\"../tests/test_files/contacts_labelled_3d.parquet\", label_sorted=True)"
+    "contacts = FileManager().load_contacts(\"../tests/test_files/contacts_labelled_3d.parquet\")"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 41,
+   "execution_count": 33,
    "metadata": {},
    "outputs": [
     {
@@ -1693,7 +1693,7 @@
        "2   4000          B  "
       ]
      },
-     "execution_count": 41,
+     "execution_count": 33,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1704,7 +1704,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 42,
+   "execution_count": 35,
    "metadata": {},
    "outputs": [
     {
@@ -1713,7 +1713,7 @@
        "(3, {'A', 'B'})"
       ]
      },
-     "execution_count": 42,
+     "execution_count": 35,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1737,7 +1737,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 44,
+   "execution_count": 37,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1746,7 +1746,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 45,
+   "execution_count": 38,
    "metadata": {},
    "outputs": [
     {
@@ -1838,7 +1838,7 @@
        "2   4000          A  "
       ]
      },
-     "execution_count": 45,
+     "execution_count": 38,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -1856,7 +1856,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 46,
+   "execution_count": 39,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -1865,7 +1865,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 47,
+   "execution_count": 40,
    "metadata": {},
    "outputs": [
     {
@@ -1957,13 +1957,79 @@
        "2   4000          A  "
       ]
      },
-     "execution_count": 47,
+     "execution_count": 40,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
     "flipped_labelled_contacts.data.head().filter(regex=\"(read_name|start|end|metadata)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Persisting contacts\n",
+    "Contacts can be persisted using the file manager, which writes the data as well as the gobal parameters to a parquet file. Loading the file restores the global parameters."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ContactsParameters(number_fragments=3, metadata_combi=None, label_sorted=True, binary_labels_equal=True, symmetry_flipped=True)"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "flipped_labelled_contacts.get_global_parameters()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "FileManager().write_multiway_contacts(\".test.parquet\", flipped_labelled_contacts)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "contacts = FileManager().load_contacts(\"test.parquet\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 46,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "ContactsParameters(number_fragments=3, metadata_combi=None, label_sorted=True, binary_labels_equal=True, symmetry_flipped=True)"
+      ]
+     },
+     "execution_count": 46,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "contacts.get_global_parameters()"
    ]
   },
   {

--- a/spoc/cli.py
+++ b/spoc/cli.py
@@ -24,7 +24,7 @@ def main():
 def expand(fragments_path, expanded_contacts_path, n_fragments):
     """Script for expanding labelled fragments to contacts"""
     expander = FragmentExpander(number_fragments=n_fragments)
-    file_manager = FileManager(verify_schemas_on_load=True)
+    file_manager = FileManager()
     input_fragments = file_manager.load_fragments(fragments_path)
     expanded = expander.expand(input_fragments)
     file_manager.write_multiway_contacts(expanded_contacts_path, expanded)
@@ -36,7 +36,7 @@ def expand(fragments_path, expanded_contacts_path, n_fragments):
 @click.argument("labelled_fragments_path")
 def annotate(fragments_path, label_library_path, labelled_fragments_path):
     """Script for annotating porec fragments"""
-    file_manager = FileManager(verify_schemas_on_load=True)
+    file_manager = FileManager()
     label_library = file_manager.load_label_library(label_library_path)
     annotator = FragmentAnnotator(label_library)
     input_fragments = file_manager.load_fragments(fragments_path)
@@ -57,7 +57,7 @@ def bin_contacts(
 ):
     """Script for binning contacts"""
     # load data from disk
-    file_manager = FileManager(verify_schemas_on_load=True, use_dask=True)
+    file_manager = FileManager(use_dask=True)
     contacts = file_manager.load_contacts(contact_path)
     # binning
     binner = GenomicBinner(
@@ -84,7 +84,7 @@ def merge():
 )
 def merge_contacts(contact_paths, n_fragments, output):
     """Functionality to merge annotated fragments"""
-    file_manager = FileManager(verify_schemas_on_load=True, use_dask=True)
+    file_manager = FileManager(use_dask=True)
     manipulator = ContactManipulator()
     contact_files = [
         file_manager.load_contacts(path, number_fragments=n_fragments) for path in contact_paths

--- a/spoc/cli.py
+++ b/spoc/cli.py
@@ -5,6 +5,7 @@ from spoc.contacts import ContactManipulator
 from spoc.fragments import FragmentAnnotator, FragmentExpander
 from spoc.io import FileManager
 from spoc.pixels import GenomicBinner
+from spoc.file_parameter_models import ContactsParameters
 
 
 @click.group()
@@ -76,18 +77,12 @@ def merge():
 @click.command(name="contacts")
 @click.argument("contact_paths", nargs=-1)
 @click.option("-o", "--output", help="output path")
-@click.option(
-    "-n",
-    "--n_fragments",
-    default=3,
-    help="Order of contacts",
-)
-def merge_contacts(contact_paths, n_fragments, output):
+def merge_contacts(contact_paths, output):
     """Functionality to merge annotated fragments"""
     file_manager = FileManager(use_dask=True)
     manipulator = ContactManipulator()
     contact_files = [
-        file_manager.load_contacts(path, number_fragments=n_fragments) for path in contact_paths
+        file_manager.load_contacts(path) for path in contact_paths
     ]
     merged = manipulator.merge_contacts(contact_files)
     file_manager.write_multiway_contacts(output, merged)

--- a/spoc/contacts.py
+++ b/spoc/contacts.py
@@ -7,6 +7,7 @@ import dask.dataframe as dd
 from typing import Union, Optional, Dict
 from itertools import permutations, product
 from spoc.dataframe_models import ContactSchema, DataFrame
+from spoc.file_parameter_models import ContactsParameters
 import numpy as np
 
 
@@ -39,6 +40,16 @@ class Contacts:
         self.label_sorted = label_sorted
         self.binary_labels_equal = binary_labels_equal
         self.symmetry_flipped = symmetry_flipped
+
+    def get_global_parameters(self) -> ContactsParameters:
+        """Returns global parameters"""
+        return ContactsParameters(
+            number_fragments=self.number_fragments,
+            metadata_combi=self.metadata_combi,
+            label_sorted=self.label_sorted,
+            binary_labels_equal=self.binary_labels_equal,
+            symmetry_flipped=self.symmetry_flipped,
+        )
 
     def _guess_number_fragments(self, contact_frame: DataFrame) -> int:
         """Guesses the number of fragments from the contact frame"""

--- a/spoc/file_parameter_models.py
+++ b/spoc/file_parameter_models.py
@@ -1,0 +1,13 @@
+"""This file contains data classes for parameters
+of spoc data structures"""
+from pydantic import BaseModel
+from typing import Optional, List
+
+class ContactsParameters(BaseModel):
+    """Parameters for multiway contacts"""
+    number_fragments: Optional[int] = None
+    number_fragments: Optional[int] = None
+    metadata_combi: Optional[List[str]] = None
+    label_sorted: bool = False
+    binary_labels_equal: bool = False
+    symmetry_flipped: bool = False

--- a/spoc/file_parameter_models.py
+++ b/spoc/file_parameter_models.py
@@ -6,7 +6,6 @@ from typing import Optional, List
 class ContactsParameters(BaseModel):
     """Parameters for multiway contacts"""
     number_fragments: Optional[int] = None
-    number_fragments: Optional[int] = None
     metadata_combi: Optional[List[str]] = None
     label_sorted: bool = False
     binary_labels_equal: bool = False

--- a/spoc/io.py
+++ b/spoc/io.py
@@ -27,15 +27,6 @@ class FileManager:
         else:
             self._parquet_reader_func = pd.read_parquet
 
-    @staticmethod
-    def _update_parquet_metadata(path:str, update_metadata: BaseModel):
-        """Update parquet metadata"""
-        md = pa.parquet.read_metadata(path)
-        metadata_dict = md.to_dict()
-        metadata_dict.update(update_metadata.dict())
-        md.set_metadata(metadata_dict)
-        pq.write_metadata(md, path)
-
     def _write_parquet_dask(self, path: str, df: dd.DataFrame, global_parameters: BaseModel) -> None:
         """Write parquet file using dask"""
         custom_meta_data = {

--- a/spoc/io.py
+++ b/spoc/io.py
@@ -1,16 +1,18 @@
 """Persisting functionality of spoc that manages writing to and reading from the filesystem."""
 
 import pickle
-from typing import Dict, Union
+from typing import Dict, Optional
+import os
+import json
 import pandas as pd
 import dask.dataframe as dd
 import pyarrow as pa
 import pyarrow.parquet as pq
-import json
 from pydantic import BaseModel
 from .contacts import Contacts
 from .pixels import Pixels
 from .dataframe_models import FragmentSchema, ContactSchema, DataFrame
+from .file_parameter_models import ContactsParameters
 from .fragments import Fragments
 
 
@@ -33,6 +35,33 @@ class FileManager:
         metadata_dict.update(update_metadata.dict())
         md.set_metadata(metadata_dict)
         pq.write_metadata(md, path)
+
+    def _write_parquet_dask(self, path: str, df: dd.DataFrame, global_parameters: BaseModel) -> None:
+        """Write parquet file using dask"""
+        custom_meta_data = {
+            'spoc'.encode(): json.dumps(global_parameters.dict()).encode()
+        }
+        dd.to_parquet(
+            df,
+            path,
+            custom_metadata=custom_meta_data
+        )
+    
+    def _write_parquet_pandas(self, path: str, df: pd.DataFrame ,global_parameters: BaseModel) -> None:
+        """Write parquet file using pandas. Pyarrow is needed because
+        the pandas .to_parquet method does not support writing custom metadata."""
+        table = pa.Table.from_pandas(df)
+        # Add metadata
+        custom_meta_key = "spoc"
+        existing_meta = table.schema.metadata
+        combined_meta = {
+            custom_meta_key.encode() : json.dumps(global_parameters.dict()).encode(),
+            **existing_meta
+        }
+        table = table.replace_schema_metadata(combined_meta)
+        # write table
+        pq.write_table(table, path)
+
 
     @staticmethod
     def write_label_library(path: str, data: Dict[str, bool]) -> None:
@@ -60,19 +89,27 @@ class FileManager:
 
     def write_multiway_contacts(self, path: str, contacts: Contacts) -> None:
         """Write multiway contacts"""
-        # Write contacts
-        contacts.data.to_parquet(path, row_group_size=1024*1024)
-        # Write metadata
-        self._update_parquet_metadata(path, contacts.get_global_parameters())
+        if contacts.is_dask:
+            self._write_parquet_dask(path, contacts.data, contacts.get_global_parameters())
+        else:
+            self._write_parquet_pandas(path, contacts.data, contacts.get_global_parameters())
         
 
-
-    # TODO; find a solution to hold information about symmetry flipping, label_sorting and binary_labeels equating
-    # -> do it with metadata of parquet file
-    def load_contacts(self, path: str, *args, **kwargs) -> Contacts:
+    def load_contacts(self, path: str, global_parameters: Optional[ContactsParameters] = None) -> Contacts:
         """Load multiway contacts"""
+        if global_parameters is None:
+            # check if path is a directory, if so, we need to read the schema from one of the partitioned files
+            if os.path.isdir(path):
+                path = path + '/' + os.listdir(path)[0]
+            global_parameters = pa.parquet.read_schema(path).metadata.get("spoc".encode())
+            if global_parameters is not None:
+                global_parameters = json.loads(global_parameters.decode())
+            else:
+                global_parameters = ContactsParameters()
+        else:
+            global_parameters = global_parameters.dict()
         return Contacts(
-            self._parquet_reader_func(path), *args, **kwargs
+            self._parquet_reader_func(path), **global_parameters
         )
 
     @staticmethod

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -21,7 +21,7 @@ CONTACT_PARAMETERS = (
                          product(*CONTACT_PARAMETERS)
                         )
 def test_write_read_contacts_global_parameters_w_metadata_pandas(unlabelled_contacts_2d, params):
-    """Test writing and reading contacts metadata """
+    """Test writing and reading contacts metadata with pandas"""
     with tempfile.TemporaryDirectory() as tmpdirname:
         file_name = tmpdirname + '/' + '_'.join([str(x) for x in params]) + '.parquet'
         contacts = Contacts(unlabelled_contacts_2d, *params)
@@ -42,5 +42,33 @@ def test_write_read_contacts_global_parameters_w_metadata_dask(unlabelled_contac
         FileManager().write_multiway_contacts(file_name, contacts)
         # read contacts
         contacts_read = FileManager(use_dask=True).load_contacts(file_name)
+        # check whether parameters are equal
+        assert contacts.get_global_parameters() == contacts_read.get_global_parameters()
+
+@pytest.mark.parametrize('params',
+                         product(*CONTACT_PARAMETERS)
+                        )
+def test_write_read_contacts_global_parameters_w_metadata_pandas_to_dask(unlabelled_contacts_2d, params):
+    """Test writing with pandas and reading with dask"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_name = tmpdirname + '/' + '_'.join([str(x) for x in params]) + '.parquet'
+        contacts = Contacts(unlabelled_contacts_2d, *params)
+        FileManager().write_multiway_contacts(file_name, contacts)
+        # read contacts
+        contacts_read = FileManager(use_dask=True).load_contacts(file_name)
+        # check whether parameters are equal
+        assert contacts.get_global_parameters() == contacts_read.get_global_parameters()
+
+@pytest.mark.parametrize('params',
+                         product(*CONTACT_PARAMETERS)
+                        )
+def test_write_read_contacts_global_parameters_w_metadata_dask_to_pandas(unlabelled_contacts_2d, params):
+    """Test writing with pandas and reading with dask"""
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_name = tmpdirname + '/' + '_'.join([str(x) for x in params]) + '.parquet'
+        contacts = Contacts(dd.from_pandas(unlabelled_contacts_2d, npartitions=2), *params)
+        FileManager().write_multiway_contacts(file_name, contacts)
+        # read contacts
+        contacts_read = FileManager(use_dask=False).load_contacts(file_name)
         # check whether parameters are equal
         assert contacts.get_global_parameters() == contacts_read.get_global_parameters()

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -1,0 +1,46 @@
+"""This file tests the io module"""
+import tempfile
+import pytest
+from itertools import product
+from spoc.contacts import Contacts
+from spoc.io import FileManager
+import dask.dataframe as dd
+from .fixtures.symmetry import (
+        unlabelled_contacts_2d
+)
+
+CONTACT_PARAMETERS = (
+    [2],
+    [['A', 'B'], ['B', 'C']],
+    [True, False],
+    [True, False],
+    [True, False],
+)
+
+@pytest.mark.parametrize('params',
+                         product(*CONTACT_PARAMETERS)
+                        )
+def test_write_read_contacts_global_parameters_w_metadata_pandas(unlabelled_contacts_2d, params):
+    """Test writing and reading contacts metadata """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_name = tmpdirname + '/' + '_'.join([str(x) for x in params]) + '.parquet'
+        contacts = Contacts(unlabelled_contacts_2d, *params)
+        FileManager().write_multiway_contacts(file_name, contacts)
+        # read contacts
+        contacts_read = FileManager().load_contacts(file_name)
+        # check whether parameters are equal
+        assert contacts.get_global_parameters() == contacts_read.get_global_parameters()
+
+@pytest.mark.parametrize('params',
+                         product(*CONTACT_PARAMETERS)
+                        )
+def test_write_read_contacts_global_parameters_w_metadata_dask(unlabelled_contacts_2d, params):
+    """Test writing and reading contacts metadata """
+    with tempfile.TemporaryDirectory() as tmpdirname:
+        file_name = tmpdirname + '/' + '_'.join([str(x) for x in params]) + '.parquet'
+        contacts = Contacts(dd.from_pandas(unlabelled_contacts_2d, npartitions=2), *params)
+        FileManager().write_multiway_contacts(file_name, contacts)
+        # read contacts
+        contacts_read = FileManager(use_dask=True).load_contacts(file_name)
+        # check whether parameters are equal
+        assert contacts.get_global_parameters() == contacts_read.get_global_parameters()


### PR DESCRIPTION
This branch implements this [trello ticket](https://trello.com/c/ehAIgm6w/73-expand-filemanager-to-include-reading-writing-metadata-for-instantiating-data-classes)  to enable reading and writing the global parameters of data structures to parquet files. 
It introduces a new module that holds the parameters of data structures as pydantic classes (`file_parameter_models.py`). This enables to handle these parameters together and define default values in a single place. At the moment, I only implemented this functionality for contacts as fragments don't have global parameters and the pixel file format is still to be done.